### PR TITLE
Remove travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-  - "3.9"
-install: python setup.py install
-script: python -m unittest discover

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 100
-


### PR DESCRIPTION
Travis hasn't worked in a long time, I'm not sure why. It will soon be replaced in this project by cibuildwheel (see #26) so I'm just eliminating travis rather than trying to fix support for it.

This also gets rid of setup.cfg which I should have deleted in PR #32. setup.cfg referenced flake8 (which I'm not currently using), and that kind of config should be in pyproject.toml now