### PR TITLE
Simplify msg queue id test comment, and add a doc file

### DIFF
--- a/extras/explore_message_queue_id.py
+++ b/extras/explore_message_queue_id.py
@@ -1,0 +1,38 @@
+import sysv_ipc
+
+def main():
+    '''This explores what happens to message queue ids when a large number of queues are created.
+
+    The POSIX spec says "msgget() shall return a non-negative integer" on success, but MacOS does
+    not respect this. As of this writing (December 2025) and for a long time prior, it has been
+    possible to get a negative queue id from msgget(). I strongly suspect that it's because
+    (a) MacOS (apparently) generates queue ids serially by adding a fixed value (e.g. 65,536)
+    to the previous queue id, and (b) that code fails to realize when it has exceeded the maximum
+    positive value of an int (2,147,483,648). It adds the fixed value to something that's just
+    short of INT_MAX which flips the sign bit and returns a negative number.
+
+    This is demonstrated by the code below. It allocates and destroys message queues until it hits
+    a negative one (or completes its max number of attempts). As of this writing, for me, this
+    reaches returns a negative queue id 100% of the time, and takes < 1 second to run.
+
+    msgget() ref: http://pubs.opengroup.org/onlinepubs/009695399/functions/msgget.html
+    '''
+    MAX_ITERATIONS = 200000
+    done = False
+    i = 0
+
+    while not done:
+        mq = sysv_ipc.MessageQueue(None, flags=sysv_ipc.IPC_CREX)
+
+        print(mq.id)
+
+        done = (mq.id < 0)
+
+        mq.remove()
+
+        done |= (i == MAX_ITERATIONS)
+
+        i += 1
+
+if __name__ =='__main__':
+    main()

--- a/tests/test_message_queues.py
+++ b/tests/test_message_queues.py
@@ -236,10 +236,8 @@ class TestMessageQueuePropertiesAndAttributes(MessageQueueTestBase):
         self.assertLessEqual(self.mq.key, sysv_ipc.KEY_MAX)
         self.assertWriteToReadOnlyPropertyFails('key', 42)
 
-    # The POSIX spec says "msgget() shall return a non-negative integer", but OS X sometimes
-    # returns a negative number like -1765146624. My guess is that they're using a UINT somewhere
-    # which exceeds INT_MAX and hence looks negative, or they just don't care about the spec.
-    # msgget() ref: http://pubs.opengroup.org/onlinepubs/009695399/functions/msgget.html
+    # The POSIX spec says "msgget() shall return a non-negative integer", but OS X does not
+    # respect this, I think due to a bug. Details are in extras/explore_message_queue_id.py.
     @unittest.skipIf(sys.platform.startswith('darwin'),
                      'OS X message queues sometimes return negative ids')
     def test_property_id(self):


### PR DESCRIPTION
When reading the comment associated with a message queue test, I wondered if it was still true so I wrote a quick script to test it. I realized how useful that script was for documentation and demonstration, so I added it to `extras` in this PR. (TL;DR MacOS is still buggy in this regard.)
