### PR TITLE
fix recently-introduced system discovery bug

### DIFF
--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -131,6 +131,8 @@ def discover():
     CONDITIONALS = ("_SEM_SEMUN_UNDEFINED",
                     # PAGE_SIZE is already #defined elsewhere on FreeBSD.
                     "PAGE_SIZE",
+                    # SEM_VALUE_MAX is often #defined in a system header file
+                    "SEM_VALUE_MAX",
                     )
 
     if os.path.exists(OUTPUT_FILEPATH):


### PR DESCRIPTION
`SEM_VALUE_MAX` was not being surrounded with #ifndef/#endif. This wasn't necessary when it was called `SEMAPHORE_VALUE_MAX`, but now that it (deliberately) echoes a system-defined constant, I need to be more careful with how it's #defined in `system_info.h`. (I introduced this bug yesterday, and it never made it to a release.)