### PR TITLE
change SEM_VALUE_MAX to SEMVMX globally

### DIFF
--- a/build_support/discover_system_info.py
+++ b/build_support/discover_system_info.py
@@ -131,8 +131,8 @@ def discover():
     CONDITIONALS = ("_SEM_SEMUN_UNDEFINED",
                     # PAGE_SIZE is already #defined elsewhere on FreeBSD.
                     "PAGE_SIZE",
-                    # SEM_VALUE_MAX is often #defined in a system header file
-                    "SEM_VALUE_MAX",
+                    # SEMVMX is often #defined in a system header file
+                    "SEMVMX",
                     )
 
     if os.path.exists(OUTPUT_FILEPATH):
@@ -155,7 +155,7 @@ def discover():
         # I hardcode the max value of a sempahore. I expect that this value is fine for most
         # users, and those that need something different can use their own system_info.h.
         # Details: https://github.com/osvenskan/sysv_ipc/issues/3
-        sys_info["SEM_VALUE_MAX"] = 32767
+        sys_info["SEMVMX"] = 32767
 
         # On some platforms, it's the responsibility of my code to define the semun union, on
         # other platforms, it's already defined in a system header file. To avoid potential

--- a/building.md
+++ b/building.md
@@ -24,4 +24,4 @@ If you want to run `sysv_ipc` on a system other than the one where it was built,
 
 ### Descriptive, Not Definitive
 
-It's very important to understand that the values in `system_info.h` _describe_ your system to `sysv_ipc`. They don't change the behavior of your operating system. For instance, if you arbitrarily change `SEM_VALUE_MAX` in `system_info.h` to a larger number, that won't actually increase the maximum valid value for a semaphore on your system. It will only misinform `sysv_ipc` about what your system accepts, and a misinformed `sysv_ipc` will probably behave badly.
+It's very important to understand that the values in `system_info.h` _describe_ your system to `sysv_ipc`. They don't change the behavior of your operating system. For instance, if you arbitrarily change `SEMVMX` in `system_info.h` to a larger number, that won't actually increase the maximum valid value for a semaphore on your system. It will only misinform `sysv_ipc` about what your system accepts, and a misinformed `sysv_ipc` will probably behave badly.

--- a/src/semaphore.c
+++ b/src/semaphore.c
@@ -123,7 +123,7 @@ sem_set_error(void) {
 
         case ERANGE:
             PyErr_Format(PyExc_ValueError,
-                "The semaphore's value must remain between 0 and SEM_VALUE_MAX");
+                "The semaphore's value must remain between 0 and SEMVMX");
         break;
 
         case EAGAIN:

--- a/src/sysv_ipc_module.c
+++ b/src/sysv_ipc_module.c
@@ -809,7 +809,7 @@ PyInit_sysv_ipc(void) {
     PyModule_AddIntConstant(module, "PAGE_SIZE", PAGE_SIZE);
     PyModule_AddIntConstant(module, "KEY_MIN", KEY_MIN);
     PyModule_AddIntConstant(module, "KEY_MAX", KEY_MAX);
-    PyModule_AddIntConstant(module, "SEMAPHORE_VALUE_MAX", SEM_VALUE_MAX);
+    PyModule_AddIntConstant(module, "SEMAPHORE_VALUE_MAX", SEMVMX);
     PyModule_AddIntConstant(module, "IPC_CREAT", IPC_CREAT);
     PyModule_AddIntConstant(module, "IPC_EXCL", IPC_EXCL);
     PyModule_AddIntConstant(module, "IPC_CREX", IPC_CREX);

--- a/system_info.sample.h
+++ b/system_info.sample.h
@@ -45,14 +45,14 @@ timeouts for acquire() on Semaphore instances.
 */
 #define SEMTIMEDOP_EXISTS
 
-/* SEM_VALUE_MAX is the maximum value of a semaphore. It's already #defined in
-system header files on many systems, so it should be surrounded with
+/* SEMVMX is the maximum value of a semaphore. It's already #defined in
+system header files on some systems, so it should be surrounded with
 #ifndef/#endif here.
 
 This value only provides information to module users. The module reports it as
 sysv_ipc.SEMAPHORE_VALUE_MAX, but that value isn't used anywhere in the
 module code, so if it's wrong, that might not matter to you.
 */
-#ifndef SEM_VALUE_MAX
-#define SEM_VALUE_MAX                   32767
+#ifndef SEMVMX
+#define SEMVMX                          32767
 #endif

--- a/tests/test_semaphores.py
+++ b/tests/test_semaphores.py
@@ -361,7 +361,7 @@ class TestSemaphorePropertiesAndAttributes(SemaphoreTestBase):
         self.assertEqual(self.sem.value, 42)
 
         # test writing out of bounds values
-        expected = "The semaphore's value must remain between 0 and SEM_VALUE_MAX"
+        expected = "The semaphore's value must remain between 0 and SEMVMX"
 
         with self.assertRaises(ValueError) as context:
             self.sem.value = -1


### PR DESCRIPTION
This turned out to be a simple change -- just find/replace `SEM_VALUE_MAX` with `SEMVMX`.

Fixes #52 