### PR TITLE
delete commented-out code from build support source

### DIFF
--- a/build_support/src/discover_page_size.c
+++ b/build_support/src/discover_page_size.c
@@ -1,4 +1,3 @@
-//#define _XOPEN_SOURCE  500
 #include <stdio.h>
 
 // Code for determining page size swiped from Python's mmapmodule.c

--- a/build_support/src/discover_semtimedop.c
+++ b/build_support/src/discover_semtimedop.c
@@ -1,4 +1,3 @@
-//#define _XOPEN_SOURCE  500
 #include <sys/sem.h>
 #include <stdlib.h>
 

--- a/build_support/src/discover_semun_union_defined.c
+++ b/build_support/src/discover_semun_union_defined.c
@@ -1,4 +1,3 @@
-//#define _XOPEN_SOURCE  500
 #include <sys/sem.h>
 
 int main(void) {


### PR DESCRIPTION
Each `.c` file in `build_support/src` had at the top `#define _XOPEN_SOURCE  500`, but those lines were commented out so they were doing nothing. This is a GNU (`gcc`) flag, documented here --
https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html

Maybe these were necessary at one time, but I don't remember and I'm too lazy to look through the file histories to see when I added them (and if they were ever not commented out). In any case, they don't seem to be necessary anymore since I got `sysv_ipc` to build fine without them on AWS Linux, OpenSUSE, Ubuntu 24, FreeBSD, and Mac. 

The lone exception is RHEL, which needs a GNU-specific flag to enable `semtimedop()` as documented in #51. Since that's the exception rather than the rule, I'm comfortable with this cleanup.



