### PR TITLE
add github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Community Support
+    url: https://groups.io/g/python-sysv-ipc/
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/simple-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/simple-issue-template.md
@@ -1,0 +1,17 @@
+---
+name: Simple issue template
+about: This is the template for all issues
+title: ''
+labels: ''
+assignees: osvenskan
+
+---
+
+Thanks for contributing to the improvement of `sysv_ipc`!
+
+Most bug reports I get are actually problems with the system where `sysv_ipc` is being installed or built. (For example -- [compiler not installed](https://github.com/osvenskan/sysv_ipc/issues/21), [unsupported Python](https://github.com/osvenskan/sysv_ipc/issues/14), [system configuration issue](https://github.com/osvenskan/sysv_ipc/issues/16), [portability problem](https://github.com/osvenskan/sysv_ipc/issues/19),
+etc.) Issues like these are best handled on the mailing list (https://groups.io/g/python-sysv-ipc/) where others can benefit from your experience (and maybe even help you figure out what's happening).
+
+If you ask about something on the mailing list and it turns out to be a bug, you can still create an issue in the bug tracker. The mailing list is the first line of support.
+
+If you still want to file a bug here, include basic platform info (Linux, Mac, etc.) and maybe the output from `uname -a`. Thanks!


### PR DESCRIPTION
My main goal is to direct people to the mailing list as the first line of support to build up a collection of troubleshooting stories (e.g. when the message is "gcc not found", you need to install gcc, that's not a `sysv_ipc` problem). 🤞 