### PR TITLE
update/improve files in extras directory

### DIFF
--- a/extras/explore_max_semaphore_value.py
+++ b/extras/explore_max_semaphore_value.py
@@ -2,13 +2,30 @@ import sysv_ipc
 
 '''This is a simple test to see how many times a semaphore can be released.'''
 
+# While POSIX semaphores sometimes have a max value of 2^31 (2,147,483,648), I don't think I've
+# seen SysV semaphores with a max value > 2^15 (32,768), with the exception of MacOS which I
+# believe is just buggy. See https://github.com/osvenskan/sysv_ipc/issues/62
+N_ATTEMPTS = 100000
+
 sem = sysv_ipc.Semaphore(None, sysv_ipc.IPC_CREX)
 
-print('Semaphore key is {}'.format(sem.key))
+print(f'Semaphore key is {sem.key}')
 
-for i in range(1, 100000):
-    sem.release()
+done = False
+i = 0
 
-    print('{:05}: value is {}'.format(i, sem.value))
+while not done:
+    try:
+        sem.release()
+    except ValueError:
+        print('Done. Max semaphore value has been reached.')
+        done = True
+    else:
+        i += 1
+        print(f'{i:05}: value is {sem.value}')
+
+        if i == N_ATTEMPTS:
+            done = True
+            print(f'Done. Max number of attempts ({N_ATTEMPTS}) has been reached.')
 
 sem.remove()

--- a/extras/explore_message_queue_id.c
+++ b/extras/explore_message_queue_id.c
@@ -1,0 +1,37 @@
+#include <errno.h>
+#include <stdio.h>
+#include <sys/ipc.h>
+#include <sys/msg.h>
+
+static const int MAX_ITERATIONS = 100000;
+
+/* This explores what happens to message queue ids when a large number of queues are created.
+
+Compile with this command:
+    cc -Wall explore_message_queue_id.c -o explore_message_queue_id
+
+Details: https://github.com/osvenskan/sysv_ipc/issues/63
+*/
+
+int main() {
+	int i = 0;
+	int done = 0;
+	int mq_id = 0;
+	struct msqid_ds mq_info;
+
+	while (!done) {
+		i += 1;
+
+		mq_id = msgget(42, IPC_CREAT | IPC_EXCL | 0600);
+
+		printf("%05d: queue id is %d\n", i, mq_id);
+
+		if ((mq_id < 0) || (i == MAX_ITERATIONS))
+			done = 1;
+
+		if (-1 == msgctl(mq_id, IPC_RMID, &mq_info))
+			printf("msgctl returned -1 on id %d, errno = %d\n", mq_id, errno);
+	}
+
+	return 0;
+}

--- a/extras/explore_message_queue_id.py
+++ b/extras/explore_message_queue_id.py
@@ -1,38 +1,31 @@
 import sysv_ipc
 
 def main():
-    '''This explores what happens to message queue ids when a large number of queues are created.
+    '''This explores what happens to message queue ids when a large number of queues are created
+    and destroyed.
 
-    The POSIX spec says "msgget() shall return a non-negative integer" on success, but MacOS does
-    not respect this. As of this writing (December 2025) and for a long time prior, it has been
-    possible to get a negative queue id from msgget(). I strongly suspect that it's because
-    (a) MacOS (apparently) generates queue ids serially by adding a fixed value (e.g. 65,536)
-    to the previous queue id, and (b) that code fails to realize when it has exceeded the maximum
-    positive value of an int (2,147,483,648). It adds the fixed value to something that's just
-    short of INT_MAX which flips the sign bit and returns a negative number.
-
-    This is demonstrated by the code below. It allocates and destroys message queues until it hits
-    a negative one (or completes its max number of attempts). As of this writing, for me, this
-    reaches returns a negative queue id 100% of the time, and takes < 1 second to run.
-
-    msgget() ref: https://pubs.opengroup.org/onlinepubs/9799919799/functions/msgget.html
+    Details: https://github.com/osvenskan/sysv_ipc/issues/63
     '''
     MAX_ITERATIONS = 200000
     done = False
     i = 0
 
     while not done:
+        i += 1
+
         mq = sysv_ipc.MessageQueue(None, flags=sysv_ipc.IPC_CREX)
 
-        print(mq.id)
+        print(f'{i:05}: queue id is {mq.id}')
 
-        done = (mq.id < 0)
+        if mq.id < 0:
+            print('Done. Negative queue id returned.')
+            done = True
+
+        if i == MAX_ITERATIONS:
+            done = True
+            print(f'Done. Max number of attempts ({MAX_ITERATIONS}) has been reached.')
 
         mq.remove()
-
-        done |= (i == MAX_ITERATIONS)
-
-        i += 1
 
 if __name__ =='__main__':
     main()

--- a/extras/explore_message_queue_receive.c
+++ b/extras/explore_message_queue_receive.c
@@ -1,0 +1,88 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/ipc.h>
+#include <sys/msg.h>
+
+/* This demonstrates the problem described in https://github.com/osvenskan/sysv_ipc/issues/38.
+
+Compile with this command:
+    cc -Wall explore_message_queue_receive.c -o explore_message_queue_receive
+
+*/
+
+const int MSG_LEN = 6;		// All of the messages I send are 6 bytes long
+
+
+void receive_message(int mq_id, long type) {
+	struct queue_message {
+	    long type;
+	    char message[];
+	};
+	struct queue_message *p_msg = NULL;
+
+	p_msg = (struct queue_message *)malloc(offsetof(struct queue_message, message) + MSG_LEN);
+    msgrcv(mq_id, p_msg, (size_t)offsetof(struct queue_message, message) + MSG_LEN, type, 0);
+
+    printf("Received message: ('%s', %ld)\n", p_msg->message, p_msg->type);
+
+    free(p_msg);
+}
+
+
+int main() {
+	int i = 0;
+	int mq_id = 0;
+	struct msqid_ds mq_info;
+	struct queue_message {
+	    long type;
+	    char message[];
+	};
+	struct queue_message *p_msg = NULL;
+	char msg_text[MSG_LEN];
+
+	// Create the queue
+	mq_id = msgget(42, IPC_CREAT | IPC_EXCL | 0600);
+
+	/* Place four messages on the queue in this order --
+		- ('type4', 4)
+		- ('type3', 3)
+		- ('type2', 2)
+		- ('type1', 1)
+	*/
+	for (i = 4; i; i--) {
+		p_msg = (struct queue_message *)malloc(offsetof(struct queue_message, message) + MSG_LEN);
+		sprintf(msg_text, "type%d", i);
+		memcpy(p_msg->message, msg_text, MSG_LEN);
+		p_msg->type = i;
+
+		msgsnd(mq_id, p_msg, (size_t)MSG_LEN, 0);
+
+		free(p_msg);
+	}
+
+	/* Receive the first message, passing a type of -2. The doc for msgrcv() says, "If msgtyp is
+	less than 0, the first message of the lowest type that is less than or equal to the absolute
+	value of msgtyp shall be received."
+	https://pubs.opengroup.org/onlinepubs/9799919799/functions/msgrcv.html
+
+	According to this logic, the message that should be returned is ('type2', 2), and this is what
+	I see under Mac OS and FreeBSD. Under Linux, I get ('type1', 1) which I believe is incorrect.
+	*/
+	receive_message(mq_id, -2);
+
+    /* Pull the remaining messages from the queue in order. They should be FIFO --
+		- ('type4', 4)
+		- ('type3', 3)
+		- ('type1', 1)
+	*/
+	for (i = 0; i < 3; i++)
+		receive_message(mq_id, 0);
+
+	if (-1 == msgctl(mq_id, IPC_RMID, &mq_info))
+		printf("msgctl returned -1 on id %d, errno = %d\n", mq_id, errno);
+
+	return 0;
+}


### PR DESCRIPTION
 - Tidy up/improve code in `explore_max_semaphore_value.py` and `explore_message_queue_id.py`
 - Add a .c version of `explore_message_queue_id.py`
 - Add `explore_message_queue_receive.c`

There are now three `explore*` topics in `extras`, each associated with a particular operating system anomaly I've observed. Ideally, each anomaly would have identical Python and C files to demonstrate the issue. The Python version is for me, the C version is for the bug report. However, writing all of that and making is nice is more work than I want to do. That's especially true for the two MacOS anomalies (max semaphore value and message queue id strangeness), because Apple seems to have done a minimal SysV IPC implementation, and I'm not convinced they'll be interested in my bug reports. I'll file one and then see if they're interested in the other.
